### PR TITLE
[Blizzard] aiohttp.get deprecated

### DIFF
--- a/blizzard/blizzard.py
+++ b/blizzard/blizzard.py
@@ -277,9 +277,9 @@ class Blizzard:
 
         tag = tag.replace("#", "-")
         url = 'https://owapi.net/api/v3/u/' + tag + '/stats'
-        async with aiohttp.ClientSession(headers=self.header) as session:
-            async with session.get(url) as resp:
-                stats = await resp.json()
+
+        async with self.session.get(url, headers=self.header) as response:
+            stats = await response.json()
 
         if 'error' in stats:
             await self.bot.say('Could not fetch your statistics. '
@@ -481,9 +481,8 @@ class Blizzard:
         url = 'https://' + region + '.api.battle.net/d3/profile/'\
               + tag + '/?locale=' + locale + '&apikey=' + key
 
-        async with aiohttp.ClientSession(headers=self.header) as session:
-            async with session.get(url) as resp:
-                stats = await resp.json()
+        async with self.session.get(url, headers=self.header) as response:
+            stats = await response.json()
 
         if 'code' in stats:
             await self.bot.say("I coulnd't find Diablo 3 stats for that battletag.")

--- a/blizzard/blizzard.py
+++ b/blizzard/blizzard.py
@@ -77,6 +77,9 @@ class Blizzard:
         self.expired_embed = discord.Embed(title="This menu has exipred due "
                                            "to inactivity.")
 
+    def __unload(self):
+        self.session.close()
+
     async def show_menu(self, ctx, message, messages, page):
         if message:
             return await self.bot.edit_message(message, messages[page])

--- a/blizzard/blizzard.py
+++ b/blizzard/blizzard.py
@@ -39,6 +39,7 @@ class Blizzard:
         self.bot = bot
         self.settings_path = "data/blizzard/settings.json"
         self.settings = dataIO.load_json(self.settings_path)
+        self.session = aiohttp.ClientSession(loop=self.bot.loop)
         self.base_url = 'https://us.battle.net/connect/en/app/'
         self.product_url = '/patch-notes?productType='
         self.wowtoken_url = 'http://wowtokenprices.com'
@@ -533,7 +534,7 @@ class Blizzard:
                        self.abbr[game]])
         tags = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'li', 'div']
         attr = {'div': 'class'}
-        async with aiohttp.get(url, headers=self.patch_header) as response:
+        async with self.session.get(url, headers=self.patch_header) as response:
             dirty = await response.text()
         clean = bleach.clean(dirty, tags=tags, attributes=attr, strip=True)
         soup = BeautifulSoup(clean, "html.parser")
@@ -625,7 +626,7 @@ class Blizzard:
         thumb_url = 'http://wowtokenprices.com/assets/wowtokeninterlaced.png'
 
         try:
-            async with aiohttp.get(url, headers=self.header) as response:
+            async with self.session.get(url, headers=self.header) as response:
                 soup = BeautifulSoup(await response.text(), "html.parser")
 
             data = soup.find('div', class_=realm + '-region-div')


### PR DESCRIPTION
```py
Exception in command 'hots notes'
Traceback (most recent call last):
  File "lib/discord/ext/commands/core.py", line 50, in wrapped
    ret = yield from coro(*args, **kwargs)
  File "/home/fixator/Red-DiscordBot/cogs/blizzard.py", line 527, in _notes_hots
    await self.format_patch_notes(ctx, 'hots')
  File "/home/fixator/Red-DiscordBot/cogs/blizzard.py", line 536, in format_patch_notes
    async with aiohttp.get(url, headers=self.patch_header) as response:
AttributeError: module 'aiohttp' has no attribute 'get'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "lib/discord/ext/commands/bot.py", line 846, in process_commands
    yield from command.invoke(ctx)
  File "lib/discord/ext/commands/core.py", line 634, in invoke
    yield from ctx.invoked_subcommand.invoke(ctx)
  File "lib/discord/ext/commands/core.py", line 374, in invoke
    yield from injected(*ctx.args, **ctx.kwargs)
  File "lib/discord/ext/commands/core.py", line 54, in wrapped
    raise CommandInvokeError(e) from e
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: AttributeError: module 'aiohttp' has no attribute 'get'
```