### PR TITLE
[smartreact] Checks for word boundaries for reacts, and solve #43

### DIFF
--- a/smartreact/smartreact.py
+++ b/smartreact/smartreact.py
@@ -116,11 +116,12 @@ class SmartReact:
         if server.id not in self.settings:
             return
         react_dict = copy.deepcopy(self.settings[server.id])
+        msg_lower = message.content.lower()
         for emoji in react_dict:
             triggers = react_dict[emoji]
             # check each trigger, in order to avoid '"trigger"' not being recognized
             for trigger in triggers:
-                if self.is_word_boundary(message.content, trigger):
+                if self.is_word_boundary(msg_lower, trigger):
                     fixed_emoji = self.fix_custom_emoji(emoji)
                     if fixed_emoji is not None:
                         await self.bot.add_reaction(message, fixed_emoji)

--- a/smartreact/smartreact.py
+++ b/smartreact/smartreact.py
@@ -13,16 +13,20 @@ class SmartReact:
         self.bot = bot
         self.settings_path = "data/smartreact/settings.json"
         self.settings = dataIO.load_json(self.settings_path)
-        self.NONWORDS = set(" ~!@#$%^&*()_=+`'\"/.,;:\\|[]\{\}<>")
+        self.NONWORDS = set(" ~!@#$%^?&*()_=+`'\"/.,;:\\|[]\{\}<>")
 
     @commands.command(name="addreact", no_pm=True, pass_context=True)
-    async def addreact(self, ctx, word, emoji):
+    async def addreact(self, ctx, *command):
         """Add an auto reaction to a word"""
         server = ctx.message.server
         message = ctx.message
         self.load_settings(server.id)
+
+        trigger = " ".join(command[0:-1])
+        emoji = command[-1]
+
         emoji = self.fix_custom_emoji(emoji)
-        await self.create_smart_reaction(server, word, emoji, message)
+        await self.create_smart_reaction(server, trigger, emoji, message)
 
     @commands.command(name="delreact", no_pm=True, pass_context=True)
     async def delreact(self, ctx, word, emoji):

--- a/smartreact/smartreact.py
+++ b/smartreact/smartreact.py
@@ -22,20 +22,20 @@ class SmartReact:
         message = ctx.message
         self.load_settings(server.id)
 
-        trigger = " ".join(command[0:-1])
-        emoji = command[-1]
-
+        trigger, emoji = parse_command(command)
         emoji = self.fix_custom_emoji(emoji)
         await self.create_smart_reaction(server, trigger, emoji, message)
 
     @commands.command(name="delreact", no_pm=True, pass_context=True)
-    async def delreact(self, ctx, word, emoji):
+    async def delreact(self, ctx, *command):
         """Delete an auto reaction to a word"""
         server = ctx.message.server
         message = ctx.message
         self.load_settings(server.id)
+
+        trigger, emoji = parse_command(command)
         emoji = self.fix_custom_emoji(emoji)
-        await self.remove_smart_reaction(server, word, emoji, message)
+        await self.remove_smart_reaction(server, trigger, emoji, message)
 
     def load_settings(self, server_id):
         self.settings = dataIO.load_json(self.settings_path)
@@ -143,6 +143,10 @@ class SmartReact:
                 return False
         return True
 
+def parse_command(command):
+    trigger = " ".join(command[0:-1])
+    emoji = command[-1]
+    return trigger, emoji
 
 def check_folders():
     folder = "data/smartreact"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3517115/36232215-e62cbff6-11ae-11e8-9ffe-5c22defe66fb.png)

I changed the logic to allow non-space word boundaries.

## Before

For trigger `!addreact hello :wave:`  
The following would *not* trigger a react:
```
hello!
"hello"
*hello*
hello~
~hello
~hello~
~~hello~~
**hello**
```

## After

For trigger  `!addreact hello :wave:`
The following *will* trigger a react:
```
hello!
"hello"
*hello*
hello~
~hello
~hello~
~~hello~~
**hello**
```

### Note
This change has been backported from the [SkyCogs](https://github.com/Skyyrunner/SkyCogs) repo--I created a fork called `smortreacts` that also accepts a react chance.