### PR TITLE
[V3 msgvote] Manage server is manage_guild

### DIFF
--- a/msgvote/msgvote.py
+++ b/msgvote/msgvote.py
@@ -41,7 +41,7 @@ class MsgVote(BaseCog):
 
     @commands.group()
     @commands.guild_only()
-    @checks.admin_or_permissions(manage_server=True)
+    @checks.admin_or_permissions(manage_guild=True)
     async def msgvote(self, ctx):
         """Msgvote cog settings"""
 


### PR DESCRIPTION
I am really hoping to use this cog as part of V3. I used it extensively in V2. This error came up when attempting to install it but it threw an error. If this can be fixed (i believe this is the correct change for the error) then it would be much appreciated.